### PR TITLE
.env file added to gotignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env


### PR DESCRIPTION
.env file contains environment variables that should not be public. Added .env to gitignore so that it is not pushed to GitHub from your local machine.